### PR TITLE
Add current Text-to-Video Retrieval results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ This repo hosts leaderboards on YouCook2 and related resources. The main tasks c
 | HGLMM        |    4.6   |   14.3   |   21.6   |         75   | CVPR 2015   | [Klein et al.](https://www.cv-foundation.org/openaccess/content_cvpr_2015/papers/Klein_Associating_Neural_Word_2015_CVPR_paper.pdf) | zero-shot; reported in [Miech et al., 2019](https://openaccess.thecvf.com/content_ICCV_2019/papers/Miech_HowTo100M_Learning_a_Text-Video_Embedding_by_Watching_Hundred_Million_Narrated_ICCV_2019_paper.pdf) |
 | Miech et al. |    6.1   |   17.3   |   24.8   |         46   | ICCV 2019   | [Miech et al.](https://openaccess.thecvf.com/content_ICCV_2019/papers/Miech_HowTo100M_Learning_a_Text-Video_Embedding_by_Watching_Hundred_Million_Narrated_ICCV_2019_paper.pdf) | zero-shot |
 | ActBERT      |    9.6   |   26.7   |   38.0   |         19   | CVPR 2020   | [Zhu et al.](https://openaccess.thecvf.com/content_CVPR_2020/papers/Zhu_ActBERT_Learning_Global-Local_Video-Text_Representations_CVPR_2020_paper.pdf) | zero-shot
-| MMV FAC      |   11.7   |   33.4   |   45.4   |         13   | arXiv 2020  | [Alayrac et al.](https://arxiv.org/pdf/2006.16228.pdf) | zero-shot |
-| MIL-NCE      |   13.9   |   36.3   |   48.9   |         11   | CVPR 2020   | [Miech et al.](https://openaccess.thecvf.com/content_CVPR_2020/papers/Miech_End-to-End_Learning_of_Visual_Representations_From_Uncurated_Instructional_Videos_CVPR_2020_paper.pdf) | zero-shot; rerun with the official [code](https://github.com/antoine77340/MIL-NCE_HowTo100M) |
-| AVLnet-Text  | **25.6** | **52.7** | **64.4** |        **5** | arXiv 2020  | [Rouditchenko et al.](https://arxiv.org/pdf/2006.09199.pdf) | zero-shot |
-| Miech et al. |    8.2   |   24.5   |   35.3   |         24   | ICCV 2019   | [Miech et al.](https://openaccess.thecvf.com/content_ICCV_2019/papers/Miech_HowTo100M_Learning_a_Text-Video_Embedding_by_Watching_Hundred_Million_Narrated_ICCV_2019_paper.pdf) | |
-| UniVL        |   28.9   |   57.6   |   70.0   |          4   | arXiv 2020  | [Luo et al.](https://arxiv.org/abs/2002.06353) | |
-| AVLNet-Text  | **33.2** | **61.0** | **71.5** |        **3** | arXiv 2020  | [Rouditchenko et al.](https://arxiv.org/pdf/2006.09199.pdf) | |
+| MIL-NCE      | **13.9** | **36.3** | **48.9** |       **11** | CVPR 2020   | [Miech et al.](https://openaccess.thecvf.com/content_CVPR_2020/papers/Miech_End-to-End_Learning_of_Visual_Representations_From_Uncurated_Instructional_Videos_CVPR_2020_paper.pdf) | zero-shot; rerun with the official [code](https://github.com/antoine77340/MIL-NCE_HowTo100M) |
+| Miech et al. |  **8.2** | **24.5** | **35.3** |       **24** | ICCV 2019   | [Miech et al.](https://openaccess.thecvf.com/content_ICCV_2019/papers/Miech_HowTo100M_Learning_a_Text-Video_Embedding_by_Watching_Hundred_Million_Narrated_ICCV_2019_paper.pdf) | |
 
 
 ## Video Captioning


### PR DESCRIPTION
I add the current Text-to-Video Retrieval results I know of.

I first put the zero-shot ones, sorted by performance, then the fine-tuned ones sorted by performance. I bold the best results for these 2 criteria. Maybe we should split it into 2 tables in the end, as how it's shown?

Seems everybody reports on val but removing those videos that are also in HowTo100M, which is cool for fair comparisons. UniVL seems to be using a tiny bit more videos it seems, as they report using 3,369:

> We filter the data and make sure there is no overlap between pre-training and evaluation data. In all, we have 1,261 training videos and 439 test videos, that is, 9,776 training clip-text pairs and 3,369 test clip-text pairs.

In any case, I think it'd be good if researchers used a metric that's less sensitive to the evaluation set size. Maybe something like the percentile (or quantile?) of the median rank? Median rank percentile. Random would be 50%. A median rank of 15/3350 would be a median rank percentile of 0.45% (the correct result is at the position 0.45% in median value). Some food for thought.

BTW, I saw also [another arXiv 2020 paper that reported results](https://arxiv.org/abs/2006.07203). However, it seems to be retracted now, so I skipped it.